### PR TITLE
Bg purchase seed

### DIFF
--- a/src/Actions/ChooseBothPlantFields.cs
+++ b/src/Actions/ChooseBothPlantFields.cs
@@ -15,14 +15,12 @@ namespace Trestlebridge.Actions
         {
             Utils.Clear();
 
+            //Lists that filter out any plowed fields or natural fields that are at capacity.
             List<PlowedField> openPlowedFields = farm.PlowedFields.Where(field => field.PlantsCount() < field.Capacity).ToList();
             List<NaturalField> openNaturalFields = farm.NaturalFields.Where(field => field.PlantsCount() < field.Capacity).ToList();
 
-            if (openPlowedFields.Count + openNaturalFields.Count == 0)
-            {
-                Console.WriteLine("0. Return to main menu");
-            }
-
+            //Prints the lists of open fields
+            Console.WriteLine("0. Return to main menu");
             for (int i = 0; i < openPlowedFields.Count; i++)
             {
                 Console.WriteLine($"{i + 1}. Plowed Field  (Plants: {openPlowedFields[i].PlantsCount()})");
@@ -48,14 +46,20 @@ namespace Trestlebridge.Actions
                     if (choice >= 1 && choice <= openPlowedFields.Count)
                     {
                         openPlowedFields[choice - 1].AddResource(plant);
+                        Console.WriteLine("The plant was successfully added to the plowed field.");
+                        Thread.Sleep(2000);
                         break;
 
                     }
                     else if (choice > openPlowedFields.Count && choice <= openPlowedFields.Count + openNaturalFields.Count)
                     {
                         openNaturalFields[choice - 1 - openPlowedFields.Count].AddResource(plant);
+                          Console.WriteLine("The plant was successfully added to the natural field.");
+                        Thread.Sleep(2000);
                         break;
-
+                    }
+                    else if(choice == 0){
+                        break;
                     }
                     else
                     {

--- a/src/Actions/ChooseBothPlantFields.cs
+++ b/src/Actions/ChooseBothPlantFields.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Trestlebridge.Interfaces;
+using Trestlebridge.Models;
+using Trestlebridge.Models.Facilities;
+
+namespace Trestlebridge.Actions
+{
+    public class ChooseBothPlantFields
+    {
+        public static void CollectInput<T>(Farm farm, T plant)
+        where T : ISeedProducing, ICompostProducingPlant
+        {
+            Utils.Clear();
+
+            List<PlowedField> openPlowedFields = farm.PlowedFields.Where(field => field.PlantsCount() < field.Capacity).ToList();
+            List<NaturalField> openNaturalFields = farm.NaturalFields.Where(field => field.PlantsCount() < field.Capacity).ToList();
+
+            if (openPlowedFields.Count + openNaturalFields.Count == 0)
+            {
+                Console.WriteLine("0. Return to main menu");
+            }
+
+            for (int i = 0; i < openPlowedFields.Count; i++)
+            {
+                Console.WriteLine($"{i + 1}. Plowed Field  (Plants: {openPlowedFields[i].PlantsCount()})");
+            }
+
+            for (int i = openPlowedFields.Count; i < openPlowedFields.Count + openNaturalFields.Count; i++)
+            {
+                Console.WriteLine($"{i + 1}. Natural Field  (Plants: {openNaturalFields[i - openPlowedFields.Count].PlantsCount()})");
+            }
+
+
+            Console.WriteLine();
+
+            // How can I output the type of animal chosen here?
+            Console.WriteLine($"Place the plant where?");
+
+            Console.Write("> ");
+            while (true)
+            {
+                try
+                {
+                    int choice = Int32.Parse(Console.ReadLine());
+                    if (choice >= 1 && choice <= openPlowedFields.Count)
+                    {
+                        openPlowedFields[choice - 1].AddResource(plant);
+                        break;
+
+                    }
+                    else if (choice > openPlowedFields.Count && choice <= openPlowedFields.Count + openNaturalFields.Count)
+                    {
+                        openNaturalFields[choice - 1 - openPlowedFields.Count].AddResource(plant);
+                        break;
+
+                    }
+                    else
+                    {
+                        Console.WriteLine("Number was not in the correct range.  Please try again");
+                        Console.Write("> ");
+                    };
+                }
+                catch (Exception)
+                {
+                    Console.WriteLine("Incorrect input.  Please try again!");
+                    Console.Write("> ");
+                }
+            }
+
+
+
+            /*
+                Couldn't get this to work. Can you?
+                Stretch goal. Only if the app is fully functional.
+             */
+            // farm.PurchaseResource<IGrazing>(animal, choice);
+
+        }
+    }
+}

--- a/src/Actions/ChooseNaturalField.cs
+++ b/src/Actions/ChooseNaturalField.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using Trestlebridge.Interfaces;
+using Trestlebridge.Models;
+using Trestlebridge.Models.Animals;
+
+namespace Trestlebridge.Actions
+{
+    public class ChooseNaturalField
+    {
+        public static void CollectInput(Farm farm, IGrazing animal)
+        {
+            Utils.Clear();
+
+            for (int i = 0; i < farm.NaturalFields.Count; i++)
+            {
+                Console.WriteLine($"{i + 1}. Natural Field");
+            }
+
+            Console.WriteLine();
+
+            // How can I output the type of animal chosen here?
+            Console.WriteLine($"Place the plant where?");
+
+            Console.Write("> ");
+            int choice = Int32.Parse(Console.ReadLine());
+
+            farm.GrazingFields[choice - 1].AddResource(animal);
+
+            /*
+                Couldn't get this to work. Can you?
+                Stretch goal. Only if the app is fully functional.
+             */
+            // farm.PurchaseResource<IGrazing>(animal, choice);
+
+        }
+    }
+}

--- a/src/Actions/ChooseNaturalField.cs
+++ b/src/Actions/ChooseNaturalField.cs
@@ -14,14 +14,11 @@ namespace Trestlebridge.Actions
         {
             Utils.Clear();
 
+            //List filtering out Natrual Fields that are at capactity
             List<NaturalField> openNaturalFields = farm.NaturalFields.Where(field => field.PlantsCount() < field.Capacity).ToList();
 
-
-            if (openNaturalFields.Count == 0)
-            {
-                Console.WriteLine("0. Return to main menu");
-            }
-
+            //Prints the list of fields that aren't at capacity
+            Console.WriteLine("0. Return to main menu");
             for (int i = 0; i < openNaturalFields.Count; i++)
             {
                 Console.WriteLine($"{i + 1}. Natural Field  (Plants: {openNaturalFields[i].PlantsCount()})");
@@ -30,23 +27,41 @@ namespace Trestlebridge.Actions
 
             Console.WriteLine();
 
-            // How can I output the type of animal chosen here?
+            // How can I output the type of plant chosen here?
             Console.WriteLine($"Place the plant where?");
 
             Console.Write("> ");
-            try
+
+            while (true)
             {
-                int choice = Int32.Parse(Console.ReadLine());
-                
-                openNaturalFields[choice - 1].AddResource(plant);
-            }
-            catch (Exception)
-            {
-                Console.WriteLine("Incorrect input.");
-                Thread.Sleep(3000);
+                try
+                {
+                    int choice = Int32.Parse(Console.ReadLine());
+                    if (choice >= 1 && choice <= openNaturalFields.Count)
+                    {
+                        openNaturalFields[choice - 1].AddResource(plant);
+                        Console.WriteLine("The plant was successfully added to the natural field.");
+                        Thread.Sleep(2000);
+                        break;
+                    }
+                    else if (choice == 0)
+                    {
+                        break;
+                    }
+                    else
+                    {
+                        Console.WriteLine("Incorrect input.  Please try again.");
+                        Console.Write("> ");
+                    }
+                }
+                catch (Exception)
+                {
+                    Console.WriteLine("Incorrect input.");
+                    Console.Write("> ");
+                }
             }
 
-            
+
 
             /*
                 Couldn't get this to work. Can you?

--- a/src/Actions/ChoosePlowedField.cs
+++ b/src/Actions/ChoosePlowedField.cs
@@ -14,12 +14,12 @@ namespace Trestlebridge.Actions
         {
             Utils.Clear();
 
+
             List<PlowedField> openPlowedFields = farm.PlowedFields.Where(field => field.PlantsCount() < field.Capacity).ToList();
 
-            if (farm.PlowedFields.Count == 0)
-            {
-                Console.WriteLine("0. Return to main menu");
-            }
+         
+                Console.WriteLine("0. Return to Main Menu");
+           
 
             for (int i = 0; i < openPlowedFields.Count; i++)
             {
@@ -29,22 +29,41 @@ namespace Trestlebridge.Actions
 
             Console.WriteLine();
 
-            // How can I output the type of animal chosen here?
+            // How can I output the type of plant chosen here?
             Console.WriteLine($"Place the plant where?");
+            
 
             Console.Write("> ");
-            try
-            {
-                int choice = Int32.Parse(Console.ReadLine());
-                openPlowedFields[choice - 1].AddResource(plant);
-            }
-            catch (Exception)
-            {
-                Console.WriteLine("Incorrect input.  Returning to main menu!");
-                Thread.Sleep(3000);
-            }
 
-            
+            //Checks that the correct input was entered.
+            while (true)
+            {
+                try
+                {
+                    int choice = Int32.Parse(Console.ReadLine());
+                    if (choice >= 1 && choice <= openPlowedFields.Count)
+                    {
+                        openPlowedFields[choice - 1].AddResource(plant);
+                        Console.WriteLine("The plant was successfully added to the plowed field.");
+                        Thread.Sleep(2000);
+                        break;
+                    }
+                    else if(choice == 0)
+                    {
+                        break;
+                    }
+                    else
+                    {
+                        Console.WriteLine("Incorrect input.  Please try again.");
+                        Console.Write("> ");
+                    }
+                }
+                catch (Exception)
+                {
+                    Console.WriteLine("Incorrect input.  Please try again.");
+                    Console.Write("> ");
+                }
+            }
 
             /*
                 Couldn't get this to work. Can you?

--- a/src/Actions/ChoosePlowedField.cs
+++ b/src/Actions/ChoosePlowedField.cs
@@ -8,23 +8,22 @@ using Trestlebridge.Models.Facilities;
 
 namespace Trestlebridge.Actions
 {
-    public class ChooseNaturalField
+    public class ChoosePlowedField
     {
-        public static void CollectInput(Farm farm, ICompostProducingPlant plant)
+        public static void CollectInput(Farm farm, ISeedProducing plant)
         {
             Utils.Clear();
 
-            List<NaturalField> openNaturalFields = farm.NaturalFields.Where(field => field.PlantsCount() < field.Capacity).ToList();
+            List<PlowedField> openPlowedFields = farm.PlowedFields.Where(field => field.PlantsCount() < field.Capacity).ToList();
 
-
-            if (openNaturalFields.Count == 0)
+            if (farm.PlowedFields.Count == 0)
             {
                 Console.WriteLine("0. Return to main menu");
             }
 
-            for (int i = 0; i < openNaturalFields.Count; i++)
+            for (int i = 0; i < openPlowedFields.Count; i++)
             {
-                Console.WriteLine($"{i + 1}. Natural Field  (Plants: {openNaturalFields[i].PlantsCount()})");
+                Console.WriteLine($"{i + 1}. Plowed Field (Plants: {openPlowedFields[i].PlantsCount()})");
             }
 
 
@@ -37,12 +36,11 @@ namespace Trestlebridge.Actions
             try
             {
                 int choice = Int32.Parse(Console.ReadLine());
-                
-                openNaturalFields[choice - 1].AddResource(plant);
+                openPlowedFields[choice - 1].AddResource(plant);
             }
             catch (Exception)
             {
-                Console.WriteLine("Incorrect input.");
+                Console.WriteLine("Incorrect input.  Returning to main menu!");
                 Thread.Sleep(3000);
             }
 

--- a/src/Actions/PurchaseSeed.cs
+++ b/src/Actions/PurchaseSeed.cs
@@ -1,31 +1,31 @@
-// using System;
-// using Trestlebridge.Interfaces;
-// using Trestlebridge.Models;
-// using Trestlebridge.Models.Facilities;
-// using Trestlebridge.Models.Plants;
+using System;
+using Trestlebridge.Interfaces;
+using Trestlebridge.Models;
+using Trestlebridge.Models.Facilities;
+using Trestlebridge.Models.Plants;
 
-// namespace Trestlebridge.Actions {
-//     public class PurchaseSeed {
-//         public static void CollectInput (Farm farm) {
-//             Console.WriteLine ("1. Sesame");
-//             Console.WriteLine ("2. Sunflower");
-//             Console.WriteLine ("3. Wildflower");
+namespace Trestlebridge.Actions {
+    public class PurchaseSeed {
+        public static void CollectInput (Farm farm) {
+            Console.WriteLine ("1. Sesame");
+            Console.WriteLine ("2. Sunflower");
+            Console.WriteLine ("3. Wildflower");
 
 
-//             Console.WriteLine ();
-//             Console.WriteLine ("Choose seed to purchase.");
+            Console.WriteLine ();
+            Console.WriteLine ("Choose seed to purchase.");
 
-//             Console.Write ("> ");
-//             string choice = Console.ReadLine ();
+            Console.Write ("> ");
+            string choice = Console.ReadLine ();
 
-//             switch (Int32.Parse(choice))
-//             {
-//                 case 1:
-//                     ChooseGrazingField.CollectInput(farm, new Sesame());
-//                     break;
-//                 default:
-//                     break;
-//             }
-//         }
-//     }
-// }
+            switch (Int32.Parse(choice))
+            {
+                case 1:
+                    // ChooseGrazingField.CollectInput(farm, new Sesame());
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/src/Actions/PurchaseSeed.cs
+++ b/src/Actions/PurchaseSeed.cs
@@ -4,33 +4,56 @@ using Trestlebridge.Models;
 using Trestlebridge.Models.Facilities;
 using Trestlebridge.Models.Plants;
 
-namespace Trestlebridge.Actions {
-    public class PurchaseSeed {
-        public static void CollectInput (Farm farm) {
-            Console.WriteLine ("1. Sesame");
-            Console.WriteLine ("2. Sunflower");
-            Console.WriteLine ("3. Wildflower");
+namespace Trestlebridge.Actions
+{
+    public class PurchaseSeed
+    {
+        public static void CollectInput(Farm farm)
+        {
+            Console.WriteLine("0. Return to Main Menu");
+            Console.WriteLine("1. Sesame");
+            Console.WriteLine("2. Sunflower");
+            Console.WriteLine("3. Wildflower");
 
 
-            Console.WriteLine ();
-            Console.WriteLine ("Choose seed to purchase.");
+            Console.WriteLine();
+            Console.WriteLine("Choose seed to purchase.");
 
-            Console.Write ("> ");
-            string choice = Console.ReadLine ();
+            Console.Write("> ");
 
-            switch (Int32.Parse(choice))
+            while (true)
             {
-                case 1:
-                    ChoosePlowedField.CollectInput(farm, new Sesame());
-                    break;
-                    case 2:
-                    ChooseBothPlantFields.CollectInput(farm, new Sunflower());
-                    break;
-                    case 3:
-                    ChooseNaturalField.CollectInput(farm, new Wildflower());
-                    break;
-                default:
-                    break;
+                try
+                {
+                    int choice = Int32.Parse(Console.ReadLine());
+                    switch (choice)
+                    {
+                        case 0:
+                            break;
+                        case 1:
+                            ChoosePlowedField.CollectInput(farm, new Sesame());
+                            break;
+                        case 2:
+                            ChooseBothPlantFields.CollectInput(farm, new Sunflower());
+                            break;
+                        case 3:
+                            ChooseNaturalField.CollectInput(farm, new Wildflower());
+                            break;
+                        default:
+                            Console.WriteLine("That is not the correct input.  Please try again.");
+                            Console.Write("> ");
+                            break;
+                    }
+                    if (choice >= 0 && choice <= 3)
+                    {
+                        break;
+                    }
+                }
+                catch
+                {
+                    Console.WriteLine("That is not the correct input.  Please try again.");
+                    Console.Write("> ");
+                }
             }
         }
     }

--- a/src/Actions/PurchaseSeed.cs
+++ b/src/Actions/PurchaseSeed.cs
@@ -55,6 +55,7 @@ namespace Trestlebridge.Actions
                     Console.Write("> ");
                 }
             }
+            Console.Write("");
         }
     }
 }

--- a/src/Actions/PurchaseSeed.cs
+++ b/src/Actions/PurchaseSeed.cs
@@ -21,7 +21,13 @@ namespace Trestlebridge.Actions {
             switch (Int32.Parse(choice))
             {
                 case 1:
-                    // ChooseGrazingField.CollectInput(farm, new Sesame());
+                    ChoosePlowedField.CollectInput(farm, new Sesame());
+                    break;
+                    case 2:
+                    ChooseBothPlantFields.CollectInput(farm, new Sunflower());
+                    break;
+                    case 3:
+                    ChooseNaturalField.CollectInput(farm, new Wildflower());
                     break;
                 default:
                     break;

--- a/src/Actions/PurchaseSeed.cs
+++ b/src/Actions/PurchaseSeed.cs
@@ -1,0 +1,31 @@
+// using System;
+// using Trestlebridge.Interfaces;
+// using Trestlebridge.Models;
+// using Trestlebridge.Models.Facilities;
+// using Trestlebridge.Models.Plants;
+
+// namespace Trestlebridge.Actions {
+//     public class PurchaseSeed {
+//         public static void CollectInput (Farm farm) {
+//             Console.WriteLine ("1. Sesame");
+//             Console.WriteLine ("2. Sunflower");
+//             Console.WriteLine ("3. Wildflower");
+
+
+//             Console.WriteLine ();
+//             Console.WriteLine ("Choose seed to purchase.");
+
+//             Console.Write ("> ");
+//             string choice = Console.ReadLine ();
+
+//             switch (Int32.Parse(choice))
+//             {
+//                 case 1:
+//                     ChooseGrazingField.CollectInput(farm, new Sesame());
+//                     break;
+//                 default:
+//                     break;
+//             }
+//         }
+//     }
+// }

--- a/src/Interfaces/ICompostProducingPlant.cs
+++ b/src/Interfaces/ICompostProducingPlant.cs
@@ -1,0 +1,9 @@
+namespace Trestlebridge.Interfaces
+{
+    //An interface used for all seed-producing plants
+    public interface ICompostProducingPlant
+    {
+        //Returns a double - how much compost this plant produces
+        double HarvestCompost();
+    }
+}

--- a/src/Models/Facilities/NaturalField.cs
+++ b/src/Models/Facilities/NaturalField.cs
@@ -3,34 +3,41 @@ using System.Text;
 using System.Collections.Generic;
 using Trestlebridge.Interfaces;
 
-namespace Trestlebridge.Models.Facilities {
+namespace Trestlebridge.Models.Facilities
+{
     //Implements the Facility interface, and this is a facility with a type of IGrazing
-    public class NaturalField : IFacility<ISeedProducing>
+    public class NaturalField : IFacility<ICompostProducingPlant>
     {
-             //Stores an int for how many resources this facility can hold (65 PLANTS)
+        //Stores an int for how many resources this facility can hold (65 PLANTS)
         private int _capacity = 60;
         //Creates a unique id 
         private Guid _id = Guid.NewGuid();
 
         //A list of plants stored in this facility
-        private List<ISeedProducing> _plants = new List<ISeedProducing>();
-           public double Capacity {
-            get {
+        private List<ICompostProducingPlant> _plants = new List<ICompostProducingPlant>();
+        public double Capacity
+        {
+            get
+            {
                 return _capacity;
             }
         }
 
-        public void AddResource(ISeedProducing resource)
+        public int PlantsCount()
         {
-            throw new NotImplementedException();
+            return _plants.Count;
+        }
+        public void AddResource(ICompostProducingPlant plant)
+        {
+            _plants.Add(plant);
         }
 
-        public void AddResource(List<ISeedProducing> resources)
+        public void AddResource(List<ICompostProducingPlant> plants)
         {
-            throw new NotImplementedException();
+            _plants.AddRange(plants);
         }
 
-         public override string ToString()
+        public override string ToString()
         {
             //Creates a new string to store the upcoming info
             StringBuilder output = new StringBuilder();
@@ -45,7 +52,7 @@ namespace Trestlebridge.Models.Facilities {
             //Returns our output string
             return output.ToString();
 
-            
+
         }
     }
 }

--- a/src/Models/Facilities/PlowedField.cs
+++ b/src/Models/Facilities/PlowedField.cs
@@ -20,14 +20,17 @@ namespace Trestlebridge.Models.Facilities {
             }
         }
 
-        public void AddResource(ISeedProducing resource)
+        public int PlantsCount(){
+            return _plants.Count;
+        }
+        public void AddResource(ISeedProducing plant)
         {
-            throw new NotImplementedException();
+             _plants.Add(plant);
         }
 
-        public void AddResource(List<ISeedProducing> resources)
+        public void AddResource(List<ISeedProducing> plants)
         {
-            throw new NotImplementedException();
+             _plants.AddRange(plants);
         }
 
          public override string ToString()

--- a/src/Models/Plants/Sunflower.cs
+++ b/src/Models/Plants/Sunflower.cs
@@ -3,7 +3,7 @@ using Trestlebridge.Interfaces;
 
 namespace Trestlebridge.Models.Plants
 {
-    public class Sunflower : IResource, ISeedProducing, ICompostProducing
+    public class Sunflower : IResource, ISeedProducing, ICompostProducingPlant
     {
         public string Type { get; } = "Sesame";
 

--- a/src/Models/Plants/Sunflower.cs
+++ b/src/Models/Plants/Sunflower.cs
@@ -1,0 +1,28 @@
+using System;
+using Trestlebridge.Interfaces;
+
+namespace Trestlebridge.Models.Plants
+{
+    public class Sunflower : IResource, ISeedProducing, ICompostProducing
+    {
+        public string Type { get; } = "Sesame";
+
+        private int _seedsProduced = 150;
+
+        private double _compostProduced = 0.36;
+        public double Harvest()
+        {
+            return _seedsProduced;
+        }
+
+        public double HarvestCompost()
+        {
+            return _compostProduced;
+        }
+
+        public override string ToString()
+        {
+            return $"Sunflower. Yum!";
+        }
+    }
+}

--- a/src/Models/Plants/Wildflower.cs
+++ b/src/Models/Plants/Wildflower.cs
@@ -1,0 +1,22 @@
+using System;
+using Trestlebridge.Interfaces;
+
+namespace Trestlebridge.Models.Plants
+{
+    public class Wildflower : IResource, ICompostProducingPlant
+    {
+        private double _compostProduced = 0.51;
+        public string Type { get; } = "Wildflower";
+
+        public double HarvestCompost()
+        {
+            return 0.51;
+        }
+
+        public override string ToString () {
+            return $"Wildflower. Yum!";
+        }
+    }
+
+    
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -66,7 +66,7 @@ namespace Trestlebridge
                  else if (option == "3")
                 {
                     DisplayBanner();
-                    //TODO:  Implement PurchaseSeed after it is built
+                    PurchaseSeed.CollectInput(Trestlebridge);
                 }
                 else if (option == "4")
                 {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -36,7 +36,6 @@ namespace Trestlebridge
             //instance of a new farm type
             Farm Trestlebridge = new Farm();
 
-
             //main menu
             while (true)
             {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -64,6 +64,11 @@ namespace Trestlebridge
                     DisplayBanner();
                     PurchaseStock.CollectInput(Trestlebridge);
                 }
+                 else if (option == "3")
+                {
+                    DisplayBanner();
+                    //TODO:  Implement PurchaseSeed after it is built
+                }
                 else if (option == "4")
                 {
                     DisplayBanner();


### PR DESCRIPTION
# Description

Users now have the ability to purchase different seeds and add them to the appropriate fields.

## Related Tickets
https://trello.com/c/C3rED41W/1-users-can-purchase-seed-stock
https://trello.com/c/YHrEfMmx/9-user-can-only-choose-among-appropriate-fields-that-have-enough-capacity
https://trello.com/c/kE35rd7x/3-users-can-only-choose-among-appropriate-fields-for-a-given-seed
https://trello.com/c/q6svZUMA/4-users-can-see-the-total-number-of-plants-in-a-selected-field

## Steps to Test:

- Save, add, and commit your own branch.  Checkout and pull bg-purchasing-seed.
- Use dotnet run in the src folder to run the program.
- As a test, try choosing option 3 before we do any setup.  Choose a Sesame.  Make sure no facilities show up because none have been made yet, and that you have Option 0 to return to the main menu.
- Use option 1 to add a plowed field and a natural field.
- Try purchasing a Sesame and make sure that only plowed fields with the number of plants they contain are printed as options.  Try adding Sesame to a plowed field.  Make sure a confirmation message appears.
- Try purchasing a Sunflower.  You should see plowed fields and natural fields show up as options.  The number of plants each field contains should be printed next to them.  Add Sunflowers to both a plowed field and a natural field. Make sure a confirmation message appears.
- Try purchasing a Wildflower.  Only natural fields with the number of plants they contain are printed as options.  Try adding a Wildflower to a natural field. Make sure a confirmation message appears.
- When adding flowers try to input chars, strings, and ints outside of the range of the list of fields to check for errors.
- Try to fill the fields to capacity (You have my permission to temporarily alter my code to reduce the fields' capacity because it is very large).  Make sure that when the field reaches capacity, it no longer prints as an option to add flowers.  After fields have been removed, check to make sure new flowers are being added to the correct fields.
- Once you're done adding, use option 4 on the main menu to pull up a report of the farm.

## What I added:

- Classes for every type of plant list in the ReadMe.
- Interfaces for plants that produce seeds and plants that produce compost.
- Implemented interfaces for each type of plant.
- Three new classes for the fields.  ChoosePlowedFields, ChooseNaturalFields, ChooseBothPlantFields.  All three contain methods that return a plant count.
- The option to Purchase Seed in the Program.cs menu.
- PurchaseSeed.cs class to handle the logic for the plant selection.

## Checklist

- [x] When purchasing seeds you should be able to purchase Sesame, Sunflowers, and Wildflowers.
- [x] When choosing a Sesame, plowed fields should be the only options to add the Sesame.
- [x] When choosing a Sunflower, plowed fields and natural fields should appear as options to add the Sunflower.
- [x] When choosing a Wildflower,  natural fields should be the only options to add the Wildflower.
- [x] If no viable fields exist, you should see the option to input 0 to return to the main menu.
- [x] Plowed fields and natural fields have counts beside them showing how many plants they contain.
- [x] A field that has reached capacity should no longer be printed after selecting a seed.
- [x] Option 4 of the main menu should show each field you created and each plant contained in those fields.



