### PR TITLE
Typecasting, Facility Fix, and Animal Counts

### DIFF
--- a/src/Actions/ChooseChickenHouse.cs
+++ b/src/Actions/ChooseChickenHouse.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Trestlebridge.Interfaces;
 using Trestlebridge.Models;
 using Trestlebridge.Models.Animals;
+using Trestlebridge.Models.Facilities;
 
 namespace Trestlebridge.Actions
 {
@@ -14,17 +16,19 @@ namespace Trestlebridge.Actions
             Boolean placeBoolean = true;
             Utils.Clear();
 
-            if(farm.ChickenHouses.Count == 0){
+            List<ChickenHouse> availableHouses = farm.ChickenHouses.Where(singleHouse => singleHouse.AnimalCount < singleHouse.Capacity).ToList(); 
+
+            if(availableHouses.Count == 0){
                     Console.WriteLine("0. Return to main menu");
             }
 
-            for (int i = 0; i < farm.ChickenHouses.Count; i++)
+            for (int i = 0; i < availableHouses.Count; i++)
             {
                 if (i == 0)
                 {
                     Console.WriteLine("0. Return to main menu");
                 }
-                Console.WriteLine($"{i + 1}. Chicken House ({farm.ChickenHouses[i].AnimalCount} animals, out of {farm.ChickenHouses[i].Capacity})");
+                Console.WriteLine($"{i + 1}. Chicken House ({availableHouses[i].AnimalCount} animals, out of {availableHouses[i].Capacity})");
             }
 
             Console.WriteLine();
@@ -51,11 +55,11 @@ namespace Trestlebridge.Actions
                     choiceBoolean = false;
                     placeBoolean = false;
                 }
-                else if (choice < 1 || choice > farm.ChickenHouses.Count)
+                else if (choice < 1 || choice > availableHouses.Count)
                 {
                     Console.WriteLine("Please input a number corresponding to a choice");
                 }
-                else if (farm.ChickenHouses[choice - 1].AnimalCount >= farm.ChickenHouses[choice - 1].Capacity)
+                else if (availableHouses[choice - 1].AnimalCount >= availableHouses[choice - 1].Capacity)
                 {
                     Console.WriteLine("This house is full, please choose another!");
                 }
@@ -67,7 +71,7 @@ namespace Trestlebridge.Actions
 
             if (placeBoolean)
             {
-                farm.ChickenHouses[choice - 1].AddResource(animal);
+                availableHouses[choice - 1].AddResource(animal);
                 Console.WriteLine("Chicken successfully added to the house! Press enter to return to the main menu.");
                 Console.ReadLine();
             }

--- a/src/Actions/ChooseChickenHouse.cs
+++ b/src/Actions/ChooseChickenHouse.cs
@@ -28,7 +28,11 @@ namespace Trestlebridge.Actions
                 {
                     Console.WriteLine("0. Return to main menu");
                 }
-                Console.WriteLine($"{i + 1}. Chicken House ({availableHouses[i].AnimalCount} animals, out of {availableHouses[i].Capacity})");
+                string chickenString = "chicken";
+                if (availableHouses[i].AnimalCount != 1){
+                    chickenString += "s";
+                }
+                Console.WriteLine($"{i + 1}. Chicken House ({availableHouses[i].AnimalCount} {chickenString})");
             }
 
             Console.WriteLine();

--- a/src/Actions/ChooseDuckHouse.cs
+++ b/src/Actions/ChooseDuckHouse.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Trestlebridge.Interfaces;
 using Trestlebridge.Models;
 using Trestlebridge.Models.Animals;
+using Trestlebridge.Models.Facilities;
 
 namespace Trestlebridge.Actions
 {
@@ -14,17 +16,19 @@ namespace Trestlebridge.Actions
             Boolean placeBoolean = true;
             Utils.Clear();
 
-            if(farm.DuckHouses.Count == 0){
+            List<DuckHouse> availableHouses = farm.DuckHouses.Where(singleHouse => singleHouse.AnimalCount < singleHouse.Capacity).ToList(); 
+
+            if(availableHouses.Count == 0){
                     Console.WriteLine("0. Return to main menu");
             }
 
-            for (int i = 0; i < farm.DuckHouses.Count; i++)
+            for (int i = 0; i < availableHouses.Count; i++)
             {
                 if (i == 0)
                 {
                     Console.WriteLine("0. Return to main menu");
                 }
-                Console.WriteLine($"{i + 1}. Duck House ({farm.DuckHouses[i].AnimalCount} animals, out of {farm.DuckHouses[i].Capacity})");
+                Console.WriteLine($"{i + 1}. Duck House ({availableHouses[i].AnimalCount} animals, out of {availableHouses[i].Capacity})");
             }
 
             Console.WriteLine();
@@ -51,11 +55,11 @@ namespace Trestlebridge.Actions
                     choiceBoolean = false;
                     placeBoolean = false;
                 }
-                else if (choice < 1 || choice > farm.DuckHouses.Count)
+                else if (choice < 1 || choice > availableHouses.Count)
                 {
                     Console.WriteLine("Please input a number corresponding to a choice");
                 }
-                else if (farm.DuckHouses[choice - 1].AnimalCount >= farm.DuckHouses[choice - 1].Capacity)
+                else if (availableHouses[choice - 1].AnimalCount >= availableHouses[choice - 1].Capacity)
                 {
                     Console.WriteLine("This house is full, please choose another!");
                 }
@@ -67,7 +71,7 @@ namespace Trestlebridge.Actions
 
             if (placeBoolean)
             {
-                farm.DuckHouses[choice - 1].AddResource(animal);
+                availableHouses[choice - 1].AddResource(animal);
                 Console.WriteLine("Duck successfully added to the house! Press enter to return to the main menu.");
                 Console.ReadLine();
             }

--- a/src/Actions/ChooseDuckHouse.cs
+++ b/src/Actions/ChooseDuckHouse.cs
@@ -28,7 +28,11 @@ namespace Trestlebridge.Actions
                 {
                     Console.WriteLine("0. Return to main menu");
                 }
-                Console.WriteLine($"{i + 1}. Duck House ({availableHouses[i].AnimalCount} animals, out of {availableHouses[i].Capacity})");
+                string duckString = "duck";
+                if (availableHouses[i].AnimalCount != 1){
+                    duckString += "s";
+                }
+                Console.WriteLine($"{i + 1}. Duck House ({availableHouses[i].AnimalCount} {duckString})");
             }
 
             Console.WriteLine();

--- a/src/Actions/ChooseGrazingField.cs
+++ b/src/Actions/ChooseGrazingField.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Trestlebridge.Interfaces;
 using Trestlebridge.Models;
 using Trestlebridge.Models.Animals;
+using Trestlebridge.Models.Facilities;
 
 namespace Trestlebridge.Actions
 {
@@ -15,16 +17,18 @@ namespace Trestlebridge.Actions
             IResource animalResource = (IResource) animal;
             Utils.Clear();
 
-            if(farm.GrazingFields.Count == 0){
+            List<GrazingField> availableFields = farm.GrazingFields.Where(singleField => singleField.AnimalCount < singleField.Capacity).ToList(); 
+
+            if(availableFields.Count == 0){
                     Console.WriteLine("0. Return to main menu");
             }
 
-            for (int i = 0; i < farm.GrazingFields.Count; i++)
+            for (int i = 0; i < availableFields.Count; i++)
             {
                 if(i == 0){
                     Console.WriteLine("0. Return to main menu");
                 }
-                Console.WriteLine($"{i + 1}. Grazing Field ({farm.GrazingFields[i].AnimalCount} animals, out of {farm.GrazingFields[i].Capacity})");
+                Console.WriteLine($"{i + 1}. Grazing Field ({availableFields[i].AnimalCount} animals, out of {availableFields[i].Capacity})");
             }
 
             Console.WriteLine();
@@ -50,11 +54,11 @@ namespace Trestlebridge.Actions
                     choiceBoolean = false;
                     placeBoolean = false;
                 }
-                else if (choice < 1 || choice > farm.GrazingFields.Count)
+                else if (choice < 1 || choice > availableFields.Count)
                 {
                     Console.WriteLine("Please input a number corresponding to a choice");
                 }
-                else if (farm.GrazingFields[choice - 1].AnimalCount >= farm.GrazingFields[choice - 1].Capacity)
+                else if (availableFields[choice - 1].AnimalCount >= availableFields[choice - 1].Capacity)
                 {
                         Console.WriteLine("This field is full, please choose another!");
                 }
@@ -66,7 +70,7 @@ namespace Trestlebridge.Actions
 
             if (placeBoolean)
             {
-                farm.GrazingFields[choice - 1].AddResource(animal);
+                availableFields[choice - 1].AddResource(animal);
                 Console.WriteLine($"{animalResource.Type} successfully added to the field! Press enter to return to the main menu.");
                 Console.ReadLine();
             }

--- a/src/Actions/ChooseGrazingField.cs
+++ b/src/Actions/ChooseGrazingField.cs
@@ -28,7 +28,32 @@ namespace Trestlebridge.Actions
                 if(i == 0){
                     Console.WriteLine("0. Return to main menu");
                 }
-                Console.WriteLine($"{i + 1}. Grazing Field ({availableFields[i].AnimalCount} animals, out of {availableFields[i].Capacity})");
+
+                var fieldsAndTheirAnimalCounts = availableFields[i].AnimalBreakdown;
+
+                string animalCountString = "";
+
+                for (int j = 0; j < fieldsAndTheirAnimalCounts.Count; j++){
+                    if(j == 0){
+                        animalCountString += "(";
+                    }
+                    foreach (KeyValuePair<string, int> animalKeyValuePair in fieldsAndTheirAnimalCounts[j]){
+                        if (animalKeyValuePair.Value > 1){
+                            animalCountString += $"{animalKeyValuePair.Value} {animalKeyValuePair.Key}s";
+                        }
+                        else{
+                            animalCountString += $"{animalKeyValuePair.Value} {animalKeyValuePair.Key}";
+                        }
+                    };
+                    if (j != fieldsAndTheirAnimalCounts.Count - 1){
+                        animalCountString += ", ";
+                    }
+                    else{
+                        animalCountString += ")";
+                    }
+                }
+
+                Console.WriteLine($"{i + 1}. Grazing Field {animalCountString}");
             }
 
             Console.WriteLine();

--- a/src/Actions/ChooseGrazingField.cs
+++ b/src/Actions/ChooseGrazingField.cs
@@ -12,12 +12,13 @@ namespace Trestlebridge.Actions
         {
             Boolean choiceBoolean = true;
             Boolean placeBoolean = true;
+            IResource animalResource = (IResource) animal;
             Utils.Clear();
 
             if(farm.GrazingFields.Count == 0){
                     Console.WriteLine("0. Return to main menu");
             }
-            
+
             for (int i = 0; i < farm.GrazingFields.Count; i++)
             {
                 if(i == 0){
@@ -29,7 +30,7 @@ namespace Trestlebridge.Actions
             Console.WriteLine();
 
             // How can I output the type of animal chosen here?
-            Console.WriteLine($"Place the {animal.Type} where?");
+            Console.WriteLine($"Place the {animalResource.Type} where?");
 
             int choice = -1;
 
@@ -66,7 +67,7 @@ namespace Trestlebridge.Actions
             if (placeBoolean)
             {
                 farm.GrazingFields[choice - 1].AddResource(animal);
-                Console.WriteLine($"{animal.Type} successfully added to the field! Press enter to return to the main menu.");
+                Console.WriteLine($"{animalResource.Type} successfully added to the field! Press enter to return to the main menu.");
                 Console.ReadLine();
             }
 

--- a/src/Interfaces/IGrazing.cs
+++ b/src/Interfaces/IGrazing.cs
@@ -5,7 +5,6 @@ namespace Trestlebridge.Interfaces
     {
         //A double to store how much grass a grazing animal can eat per day
         double GrassPerDay { get; set; }
-        string Type{get;}
         //A blueprint method, will print a line about how much grass an animal ate in one day
         void Graze();
     }

--- a/src/Models/Facilities/ChickenHouse.cs
+++ b/src/Models/Facilities/ChickenHouse.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Linq;
 using System.Collections.Generic;
 using Trestlebridge.Interfaces;
 using Trestlebridge.Models.Animals;

--- a/src/Models/Facilities/GrazingField.cs
+++ b/src/Models/Facilities/GrazingField.cs
@@ -60,8 +60,6 @@ namespace Trestlebridge.Models.Facilities {
 
             //Returns our output string
             return output.ToString();
-
-            
         }
     }
 }

--- a/src/Models/Facilities/GrazingField.cs
+++ b/src/Models/Facilities/GrazingField.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Linq;
 using System.Collections.Generic;
 using Trestlebridge.Interfaces;
 
@@ -28,6 +29,18 @@ namespace Trestlebridge.Models.Facilities {
         public int AnimalCount {
             get {
                 return _animals.Count;
+            }
+        }
+
+        public List<Dictionary<string, int>> AnimalBreakdown {
+            get {
+                List<IResource> animalResources = _animals.Select(animal => (IResource)animal).ToList();
+                
+                return animalResources.GroupBy(
+                singleAnimal => singleAnimal.Type,
+                (key, animalList) => new Dictionary<string, int>() {
+                    {key, animalList.ToList().Count()}
+                }).ToList();
             }
         }
 


### PR DESCRIPTION
# Description
Full facilities no longer show up when purchasing new animals. Grazing fields should be accompanied with counts of how many of each animal are stored in them. Also implemented typecasting to reduce redundancy between IGrazing and IResource.

## Related tickets
https://trello.com/c/vpnBtqyG/10-user-can-only-choose-among-appropriate-facilities-that-have-enough-capacity
https://trello.com/c/vRni5hGO/8-user-can-see-count-of-each-type-of-animal
https://trello.com/c/gsBVUfoP/22-fix-overlap-between-igrazing-and-iresource

## Steps to Test:
- Save, add, and commit your own branch. Checkout and pull bg-purchasing-seed.
- Use dotnet run in the src folder to run the program.
- Use option 1 to add a grazing field, a chicken house, and a duck house.
- Use option 2 to add a cow and 2 pigs to the grazing field, a chicken to the chicken house, and a duck to the duck house.
- Observe that the program is correctly identifying the animal as you are adding it (ie. "Cow added to grazing field" rather than "Animal added to grazing field")
- When adding the duplicate animals to each facility, observe that the animal count and breakdown for each facility is correct.
- Fill a facility and verify that it is removed from option 2 when full. (If needed, alter the capacity for a facility in the code to make this easier.)

## What I added:
- An AnimalBreakdown property in GrazingField.cs. This sorts the _animals list by animal type using a GroupBy method, and returns the list to whatever called the property.
- In ChooseGrazingField, I added logic to call the aforementioned AnimalBreakdown and print the counts into a string. Logic also exists to add commas, plurality, and parentheses where needed.
- In both ChooseChickenHouse and ChooseDuckHouse, I added a few lines of code to show plurality and singularity when chickens are already stored in the houses (ie. it now shows "1 Chicken" instead of "1 Chickens")

## Checklist
- [x] When adding animals to a facility, each facility is accompanied by a breakdown of the animals and counts stored within
- [x] When adding animals to a facility, full facilities do not appear.
- [x] When adding animals to a facility, the program calls each newly purchased animal by the appropriate name.
- [ ] When adding chickens or ducks, proper grammar is used for the counts of each facility.