### PR TITLE
Bg plant count

### DIFF
--- a/src/Actions/ChooseBothPlantFields.cs
+++ b/src/Actions/ChooseBothPlantFields.cs
@@ -23,12 +23,12 @@ namespace Trestlebridge.Actions
             Console.WriteLine("0. Return to main menu");
             for (int i = 0; i < openPlowedFields.Count; i++)
             {
-                Console.WriteLine($"{i + 1}. Plowed Field  (Plants: {openPlowedFields[i].PlantsCount()})");
+                Console.WriteLine($"{i + 1}. Plowed Field  (Plants: {openPlowedFields[i].PlantsCount()} Sesame: {openPlowedFields[i].SesameCount()} Sunflower: {openPlowedFields[i].SunflowerCount()})");
             }
 
             for (int i = openPlowedFields.Count; i < openPlowedFields.Count + openNaturalFields.Count; i++)
             {
-                Console.WriteLine($"{i + 1}. Natural Field  (Plants: {openNaturalFields[i - openPlowedFields.Count].PlantsCount()})");
+                Console.WriteLine($"{i + 1}. Natural Field  (Plants: {openNaturalFields[i - openPlowedFields.Count].PlantsCount()} Sunflower: {openNaturalFields[i - openPlowedFields.Count].SunflowerCount()} Wildflower: {openNaturalFields[i - openPlowedFields.Count].WildflowerCount()})");
             }
 
 

--- a/src/Actions/ChooseNaturalField.cs
+++ b/src/Actions/ChooseNaturalField.cs
@@ -21,7 +21,7 @@ namespace Trestlebridge.Actions
             Console.WriteLine("0. Return to main menu");
             for (int i = 0; i < openNaturalFields.Count; i++)
             {
-                Console.WriteLine($"{i + 1}. Natural Field  (Plants: {openNaturalFields[i].PlantsCount()})");
+                Console.WriteLine($"{i + 1}. Natural Field  (Plants: {openNaturalFields[i].PlantsCount()} Sunflower: {openNaturalFields[i].SunflowerCount()} Wildflower: {openNaturalFields[i].WildflowerCount()}) ");
             }
 
 

--- a/src/Actions/ChoosePlowedField.cs
+++ b/src/Actions/ChoosePlowedField.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Trestlebridge.Interfaces;
 using Trestlebridge.Models;
 using Trestlebridge.Models.Facilities;
+using Trestlebridge.Models.Plants;
 
 namespace Trestlebridge.Actions
 {
@@ -16,14 +17,15 @@ namespace Trestlebridge.Actions
 
 
             List<PlowedField> openPlowedFields = farm.PlowedFields.Where(field => field.PlantsCount() < field.Capacity).ToList();
-
+            
          
                 Console.WriteLine("0. Return to Main Menu");
            
 
             for (int i = 0; i < openPlowedFields.Count; i++)
             {
-                Console.WriteLine($"{i + 1}. Plowed Field (Plants: {openPlowedFields[i].PlantsCount()})");
+                Console.WriteLine($"{i + 1}. Plowed Field (Total Plants: {openPlowedFields[i].PlantsCount()} Total Sesame: {openPlowedFields[i].SesameCount()} Total Sunflower: {openPlowedFields[i].SunflowerCount()}) ");
+                
             }
 
 

--- a/src/Interfaces/ICompostProducingPlant.cs
+++ b/src/Interfaces/ICompostProducingPlant.cs
@@ -5,5 +5,7 @@ namespace Trestlebridge.Interfaces
     {
         //Returns a double - how much compost this plant produces
         double HarvestCompost();
+
+        string Type {get;}
     }
 }

--- a/src/Interfaces/ISeedProducing.cs
+++ b/src/Interfaces/ISeedProducing.cs
@@ -5,5 +5,8 @@ namespace Trestlebridge.Interfaces
     {
         //Returns a double - how many seeds this resource produces
         double Harvest ();
+
+        string Type {get;}
+
     }
 }

--- a/src/Models/Facilities/NaturalField.cs
+++ b/src/Models/Facilities/NaturalField.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using System.Collections.Generic;
 using Trestlebridge.Interfaces;
+using System.Linq;
 
 namespace Trestlebridge.Models.Facilities
 {
@@ -26,6 +27,34 @@ namespace Trestlebridge.Models.Facilities
         public int PlantsCount()
         {
             return _plants.Count;
+        }
+
+        public int SunflowerCount()
+        {
+            int count = 0;
+            count = _plants.Where(plant => plant.Type == "Sunflower").Count();
+            return count;
+        }
+
+        public int WildflowerCount()
+        {
+            int count = 0;
+            count = _plants.Where(plant => plant.Type == "Wildflower").Count();
+            return count;
+        }
+
+        public List<Dictionary<string, int>> PlantGroups
+        {
+            get
+            {
+                List<IResource> PlantList = _plants.Select(plant => (IResource)plant).ToList();
+
+                return PlantList.GroupBy(
+                plant => plant.Type,
+                (key, plantList) => new Dictionary<string, int>() {
+                    {key, plantList.ToList().Count()}
+                }).ToList();
+            }
         }
         public void AddResource(ICompostProducingPlant plant)
         {

--- a/src/Models/Facilities/PlowedField.cs
+++ b/src/Models/Facilities/PlowedField.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using System.Collections.Generic;
 using Trestlebridge.Interfaces;
+using System.Linq;
 
 namespace Trestlebridge.Models.Facilities {
     //Implements the Facility interface, and this is a facility with a type of IGrazing
@@ -13,13 +14,28 @@ namespace Trestlebridge.Models.Facilities {
         private Guid _id = Guid.NewGuid();
 
         //A list of plants stored in this facility
-        private List<ISeedProducing> _plants = new List<ISeedProducing>();
+        public List<ISeedProducing> _plants = new List<ISeedProducing>();
+
+       
+
            public double Capacity {
             get {
                 return _capacity;
             }
         }
 
+
+    public int SesameCount(){
+        int count = 0;
+        count = _plants.Where(plant => plant.Type == "Sesame").Count();
+        return count;
+    }
+
+       public int SunflowerCount(){
+        int count = 0;
+        count = _plants.Where(plant => plant.Type == "Sunflower").Count();
+        return count;
+    }
         public int PlantsCount(){
             return _plants.Count;
         }

--- a/src/Models/Plants/Sunflower.cs
+++ b/src/Models/Plants/Sunflower.cs
@@ -5,7 +5,7 @@ namespace Trestlebridge.Models.Plants
 {
     public class Sunflower : IResource, ISeedProducing, ICompostProducingPlant
     {
-        public string Type { get; } = "Sesame";
+        public string Type { get; } = "Sunflower";
 
         private int _seedsProduced = 150;
 


### PR DESCRIPTION
## Trello Cards
https://trello.com/c/n01FmC8h/7-user-can-see-counts-of-each-type-of-plant

## Steps to Test
- Save, add, and commit your own branch. Checkout and pull bg-plant-count.
- Use dotnet run in the src folder to run the program.
- Use option 1 in the main menu to add a plowed field and a natural field.
- Use option 3 in the main menu and add a Sesame to the Plowed Field.
- Use option 3 in the main menu and add a Sunflower to the Plowed Field.  You should see 1 plant  and 1 Sesame in the Plowed Field.
- Use option 3 in the main menu and add a Sunflower to the Natural Field.  You should see 2 plants, 1 Sesame, and 1 Sunflower in the Plowed Field.
- Use option 3 in the main menu and add a Wildflower to the Natural Field.  You should see 1 plant and 1 Sunflower in the Natural Field.

## What I Added
- A string variable called Type to the ISeedProducing and ICompostProducingPlant interfaces.
- Methods in NaturalField.cs and PlowedField.cs classes in the Facilities Folder that keep track of the counts for different plants in each field.
- Method calls in the ChooseNaturalField.cs, ChoosePlowedField.cs, and ChooseBothPlantFields.cs classes in the Actions folder that use the count methods.

## Checklist

- [x]  Is the plowed field keeping the correct count for total plants, Sesames, and Sunflowers?
- [x]  Is the natural field keeping the correct count for total plants, Sunflowers, and Wildflowers?